### PR TITLE
[Fix] 날씨 Provider 구현 완료 PerformanceImprove #82

### DIFF
--- a/weatherfit_refactoring/contexts/WeatherContext.tsx
+++ b/weatherfit_refactoring/contexts/WeatherContext.tsx
@@ -1,16 +1,34 @@
 'use client'
 import { ReactNode, createContext, useEffect, useState } from 'react'
 
+type WeatherType =
+  | 'Clear'
+  | 'Rain'
+  | 'Thunderstorm'
+  | 'Snow'
+  | 'Mist'
+  | 'Drizzle'
+  | 'Clouds'
+  | 'Fog'
+  | 'Haze'
+  | 'Sand'
 interface WeatherProvider {
-  icon: string | undefined
-  tempNow: number | undefined
-  tempMax: number | undefined
-  tempMin: number | undefined
+  icon: string | null
+  tempNow: number | null
+  tempMax: number | null
+  tempMin: number | null
+  address: string | null
+  weather: WeatherType | null
 }
 
-export const WeatherContext = createContext<WeatherProvider | undefined>(
-  undefined,
-)
+export const WeatherContext = createContext<WeatherProvider>({
+  icon: null,
+  tempMax: null,
+  tempMin: null,
+  tempNow: null,
+  address: null,
+  weather: null,
+})
 
 export const WeatherProvider = ({ children }: { children: ReactNode }) => {
   const [temperature, setTemp] = useState<number>()
@@ -19,7 +37,8 @@ export const WeatherProvider = ({ children }: { children: ReactNode }) => {
   const [weatherIcon, setIcon] = useState<string>()
   const [latitude_state, setLatitude] = useState<number>()
   const [longitude_state, setLongitude] = useState<number>()
-  const [address, setAddress] = useState<string | undefined>()
+  const [address, setAddress] = useState<string>()
+  const [weather, setWeather] = useState<WeatherType>()
 
   // API Keys
   // openweathermap
@@ -50,7 +69,6 @@ export const WeatherProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const getWeather = async () => {
-      console.log('위도', latitude_state, '경도', longitude_state)
       try {
         // OpenWeatherMap에서 위치 기반 날씨 정보 불러오기
         const weatherResponse = await fetch(
@@ -60,6 +78,7 @@ export const WeatherProvider = ({ children }: { children: ReactNode }) => {
 
         // 날씨 정보 저장하기
         setIcon(weatherData.weather[0].icon)
+        setWeather(weatherData.weather[0].main)
         setTemp(weatherData.main.temp.toFixed(1))
         setTempMax(weatherData.main.temp_max.toFixed(1))
         setTempMin(weatherData.main.temp_min.toFixed(1))
@@ -92,18 +111,29 @@ export const WeatherProvider = ({ children }: { children: ReactNode }) => {
       }
     }
 
-    if (address) getAddress()
+    getAddress()
   }, [temperatureMin])
 
   return (
-    <WeatherContext.Provider
-      value={{
-        icon: weatherIcon,
-        tempMax: temperatureMax,
-        tempMin: temperatureMin,
-        tempNow: temperature,
-      }}>
-      {children}
-    </WeatherContext.Provider>
+    <>
+      {weatherIcon &&
+        temperature &&
+        temperatureMax &&
+        weather &&
+        temperatureMin &&
+        address && (
+          <WeatherContext.Provider
+            value={{
+              icon: weatherIcon,
+              weather: weather,
+              address: address,
+              tempMax: temperatureMax,
+              tempMin: temperatureMin,
+              tempNow: temperature,
+            }}>
+            {children}
+          </WeatherContext.Provider>
+        )}
+    </>
   )
 }

--- a/weatherfit_refactoring/src/Components/Molecules/WeatherNavbar.tsx
+++ b/weatherfit_refactoring/src/Components/Molecules/WeatherNavbar.tsx
@@ -1,114 +1,26 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import Image from 'next/image'
-//Zustand
-import { WeatherIcon } from '@/Store/WeatherIcon'
-import { WeatherTemp } from '@/Store/WeatherTemp'
-import { WeatherTempMax } from '@/Store/WeatherMaxTemp'
-import { WeatherTempMin } from '@/Store/WeatherMinTemp'
+import { WeatherContext } from '../../../contexts/WeatherContext'
 
 export default function WeatherNavbar() {
-  // const API_KEY = 'fa3eba61f243af3e8e69086462763172'
-  const API_KEY = 'e88170b7fa2aeadd4ba37bb1561a53f2'
-  const KAKAO_API_KEY = '3a6c3035c801405eaa71ebb9dc7f474b'
-
-  const { temperature, setTemp } = WeatherTemp()
-  const { temperatureMin, setTempMin } = WeatherTempMin()
-  const { temperatureMax, setTempMax } = WeatherTempMax()
-  const { weatherIcon, setIcon } = WeatherIcon()
-  const [latitude_state, setLatitude] = useState<number>()
-  const [longitude_state, setLongitude] = useState<number>()
-  const [address, setAddress] = useState<string | undefined>()
-
-  // 렌더링 속도 비교해보기
-
-  useEffect(() => {
-    const getLocation = async () => {
-      try {
-        // 위치 노출이 허용되어 있는지 확인하고 현재 위치 가져오기
-        const position = await new Promise<GeolocationPosition>(
-          (resolve, reject) => {
-            navigator.geolocation.getCurrentPosition(resolve, reject)
-          },
-        )
-
-        // 위도와 경도 가져오기
-        setLatitude(position.coords.latitude)
-        setLongitude(position.coords.longitude)
-      } catch (error) {
-        console.error('Error getting location:', error)
-      }
-    }
-
-    getLocation()
-  }, [])
-
-  useEffect(() => {
-    const getWeather = async () => {
-      console.log('위도', latitude_state, '경도', longitude_state)
-      try {
-        // OpenWeatherMap에서 위치 기반 날씨 정보 불러오기
-        const weatherResponse = await fetch(
-          `https://api.openweathermap.org/data/2.5/weather?lat=${latitude_state}&lon=${longitude_state}&appid=${API_KEY}&units=metric`,
-        )
-        const weatherData = await weatherResponse.json()
-
-        // 날씨 정보 저장하기
-        setIcon(weatherData.weather[0].icon)
-        setTemp(weatherData.main.temp.toFixed(1))
-        setTempMax(weatherData.main.temp_max.toFixed(1))
-        setTempMin(weatherData.main.temp_min.toFixed(1))
-      } catch (error) {
-        console.error('Error getting location:', error)
-      }
-    }
-
-    if (latitude_state && longitude_state) getWeather()
-  }, [latitude_state, longitude_state])
-
-  useEffect(() => {
-    const getAddress = async () => {
-      try {
-        const addressResponse = await fetch(
-          `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${longitude_state}&y=${latitude_state}`,
-          {
-            method: 'GET',
-            headers: { Authorization: `KakaoAK ${KAKAO_API_KEY}` },
-          },
-        )
-        const addressData = await addressResponse.json()
-        setAddress(
-          addressData.documents[0].address.region_1depth_name +
-            ' ' +
-            addressData.documents[0].address.region_2depth_name,
-        )
-      } catch (error) {
-        console.error('Error getting location:', error)
-      }
-    }
-
-    if (address) getAddress()
-  }, [temperatureMin])
+  const { icon, tempMax, tempMin, tempNow } = useContext(WeatherContext)
 
   return (
     <article className="flex justify-between items-center text-[12px] border-t border-b border-slate-100 px-2">
       <section className="flex items-center">
         <Image
-          src={`https://openweathermap.org/img/wn/${weatherIcon}.png`}
+          src={`https://openweathermap.org/img/wn/${icon}.png`}
           alt="weatherIcon"
           width={50}
           height={50}
           loading="lazy"
         />
-        <span className="font-gmarketsans font-thin pt-1">{temperature}℃</span>
+        <span className="font-gmarketsans font-thin pt-1">{tempNow}℃</span>
       </section>
       <section className="px-1">
-        <span className="font-gmarketsans font-thin px-1">
-          최고 {temperatureMax}℃
-        </span>
-        <span className="font-gmarketsans font-thin px-1">
-          최저 {temperatureMin}℃
-        </span>
+        <span className="font-gmarketsans font-thin px-1">최고 {tempMax}℃</span>
+        <span className="font-gmarketsans font-thin px-1">최저 {tempMin}℃</span>
       </section>
     </article>
   )

--- a/weatherfit_refactoring/src/Components/Molecules/post/Weather.tsx
+++ b/weatherfit_refactoring/src/Components/Molecules/post/Weather.tsx
@@ -1,12 +1,13 @@
 import Image from 'next/image'
-import { WeatherIcon } from '@/Store/WeatherIcon'
+import { WeatherContext } from '../../../../contexts/WeatherContext'
+import { useContext } from 'react'
 
 export default function Weather({
   initialWeatherIcon,
 }: {
   initialWeatherIcon?: FEEDDATA_detail['weatherIcon']
 }) {
-  const { weatherIcon } = WeatherIcon()
+  const { icon } = useContext(WeatherContext)
   return (
     <div className="flex mb-3 items-center w-fit">
       <p className="font-gmarketsans pt-[5px] mr-3 text-sm">
@@ -16,7 +17,7 @@ export default function Weather({
         src={
           initialWeatherIcon
             ? initialWeatherIcon
-            : `https://openweathermap.org/img/wn/${weatherIcon}.png`
+            : `https://openweathermap.org/img/wn/${icon}.png`
         }
         alt="날씨"
         width={20}

--- a/weatherfit_refactoring/src/Components/Organisms/main/WeatherInfo.tsx
+++ b/weatherfit_refactoring/src/Components/Organisms/main/WeatherInfo.tsx
@@ -1,35 +1,22 @@
 'use client'
-import { WeatherIcon } from '@/Store/WeatherIcon'
-import { WeatherTempMax } from '@/Store/WeatherMaxTemp'
-import { WeatherTempMin } from '@/Store/WeatherMinTemp'
-import { WeatherTemp } from '@/Store/WeatherTemp'
+import { WeatherContext } from '../../../../contexts/WeatherContext'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import TextStore, { TextStyle } from '../../Atoms/Text/TextStore'
 
-type WeatherType =
-  | 'Clear'
-  | 'Rain'
-  | 'Thunderstorm'
-  | 'Snow'
-  | 'Mist'
-  | 'Drizzle'
-  | 'Clouds'
-  | 'Fog'
-  | 'Haze'
-  | 'Sand'
-
 export default function WeatherInfo() {
-  const API_KEY = 'fa3eba61f243af3e8e69086462763172'
-  const KAKAO_API_KEY = '3a6c3035c801405eaa71ebb9dc7f474b'
+  const { icon, tempNow, tempMax, tempMin, weather, address } =
+    useContext(WeatherContext)
+  // const API_KEY = 'fa3eba61f243af3e8e69086462763172'
+  // const KAKAO_API_KEY = '3a6c3035c801405eaa71ebb9dc7f474b'
 
-  const { temperature, setTemp } = WeatherTemp()
-  const { temperatureMin, setTempMin } = WeatherTempMin()
-  const { temperatureMax, setTempMax } = WeatherTempMax()
-  const { weatherIcon, setIcon } = WeatherIcon()
+  // const { temperature, setTemp } = WeatherTemp()
+  // const { temperatureMin, setTempMin } = WeatherTempMin()
+  // const { temperatureMax, setTempMax } = WeatherTempMax()
+  // const { weatherIcon, setIcon } = WeatherIcon()
 
-  const [weat, setWeat] = useState<WeatherType | undefined>()
-  const [address, setAddress] = useState<string | undefined>()
+  // const [weat, setWeat] = useState<WeatherType | undefined>()
+  // const [address, setAddress] = useState<string | undefined>()
 
   const weatherValue = {
     Clear: '맑음',
@@ -57,62 +44,60 @@ export default function WeatherInfo() {
     Sand: 'sand.png',
   }
 
-  useEffect(() => {
-    const getLocation = async () => {
-      try {
-        const position = await new Promise<GeolocationPosition>(
-          (resolve, reject) => {
-            navigator.geolocation.getCurrentPosition(resolve, reject)
-          },
-        )
+  // useEffect(() => {
+  //   const getLocation = async () => {
+  //     try {
+  //       const position = await new Promise<GeolocationPosition>(
+  //         (resolve, reject) => {
+  //           navigator.geolocation.getCurrentPosition(resolve, reject)
+  //         },
+  //       )
 
-        const latitude = position.coords.latitude
-        const longitude = position.coords.longitude
+  //       const latitude = position.coords.latitude
+  //       const longitude = position.coords.longitude
 
-        const weatherResponse = await fetch(
-          `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${API_KEY}&units=metric`,
-        )
-        const weatherData = await weatherResponse.json()
-        setTemp(weatherData.main.temp.toFixed(1))
-        setTempMax(weatherData.main.temp_max.toFixed(1))
-        setTempMin(weatherData.main.temp_min.toFixed(1))
-        setWeat(weatherData.weather[0].main)
-        setIcon(weatherData.weather[0].icon)
+  //       const weatherResponse = await fetch(
+  //         `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${API_KEY}&units=metric`,
+  //       )
+  //       const weatherData = await weatherResponse.json()
+  //       setTemp(weatherData.main.temp.toFixed(1))
+  //       setTempMax(weatherData.main.temp_max.toFixed(1))
+  //       setTempMin(weatherData.main.temp_min.toFixed(1))
+  //       setWeat(weatherData.weather[0].main)
+  //       setIcon(weatherData.weather[0].icon)
 
-        console.log('데이터', weatherData)
+  //       console.log('데이터', weatherData)
 
-        const addressResponse = await fetch(
-          `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${longitude}&y=${latitude}`,
-          {
-            method: 'GET',
-            headers: { Authorization: `KakaoAK ${KAKAO_API_KEY}` },
-          },
-        )
-        const addressData = await addressResponse.json()
-        setAddress(
-          addressData.documents[0].address.region_1depth_name +
-            ' ' +
-            addressData.documents[0].address.region_2depth_name,
-        )
-      } catch (error) {
-        console.error('Error getting location:', error)
-      }
-    }
+  //       const addressResponse = await fetch(
+  //         `https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${longitude}&y=${latitude}`,
+  //         {
+  //           method: 'GET',
+  //           headers: { Authorization: `KakaoAK ${KAKAO_API_KEY}` },
+  //         },
+  //       )
+  //       const addressData = await addressResponse.json()
+  //       setAddress(
+  //         addressData.documents[0].address.region_1depth_name +
+  //           ' ' +
+  //           addressData.documents[0].address.region_2depth_name,
+  //       )
+  //     } catch (error) {
+  //       console.error('Error getting location:', error)
+  //     }
+  //   }
 
-    getLocation()
-  }, [])
+  //   getLocation()
+  // }, [])
 
-  console.log(
-    `온도 : ${temperature} ,최고온도 ${temperatureMax},최저온도 ${temperatureMin}, 날씨 : ${weat}, 아이콘: ${weatherIcon}`,
-  )
-
-  console.log('주소: ', address)
+  // console.log(
+  //   `온도 : ${temperature} ,최고온도 ${temperatureMax},최저온도 ${temperatureMin}, 날씨 : ${weat}, 아이콘: ${weatherIcon}`,
+  // )
 
   return (
     <article className="relative h-[300px] flex justify-center">
-      {weat && (
+      {weather && (
         <Image
-          src={`/images/${weatherImage[weat]}`}
+          src={`/images/${weatherImage[weather]}`}
           alt="weatherimage"
           width={400}
           height={300}
@@ -127,15 +112,15 @@ export default function WeatherInfo() {
         <TextStore
           textStyle={TextStyle.NANUM_TEXT}
           style="text-white text-[45px]">
-          {temperature} ℃
+          {tempNow} ℃
         </TextStore>
         <TextStore textStyle={TextStyle.GMARKET_TEXT} style="text-black">
-          {weat && weatherValue[weat as keyof typeof weatherValue]}
+          {weather && weatherValue[weather as keyof typeof weatherValue]}
         </TextStore>
         <TextStore
           textStyle={TextStyle.GMARKET_TEXT}
           style="text-[#616161] text-[14px]">
-          최고 {temperatureMax}℃ / 최저 {temperatureMin}℃
+          최고 {tempMax}℃ / 최저 {tempMin}℃
         </TextStore>
       </div>
     </article>


### PR DESCRIPTION
기존 날씨 데이터 불러오는 과정 :
메인 페이지와 피드 페이지 각각 데이터 호출 >> 거기서 불러온 아이콘 데이터를 업로드 페이지에서 사용
==> 위 과정으로 인해 업로드 페이지에 단일로 들어가면 날씨 아이콘 표시가 안됨

날씨 Provider는 데이터가 필요할 때, 호출하여 원하는 데이터 사용
==> 이를 통해 기존 업로드 페이지에서 날씨 아이콘 표시가 안되던 문제 해결