### PR TITLE
[Fix] Atom의 생 enum 타입을 const enum으로 변경

### DIFF
--- a/weatherfit_refactoring/src/Components/Atoms/Box/BoxStore.tsx
+++ b/weatherfit_refactoring/src/Components/Atoms/Box/BoxStore.tsx
@@ -1,6 +1,4 @@
-import { MouseEventHandler } from 'react'
-
-export enum BoxStyle {
+export const enum BoxStyle {
   BOX_WHITE = 'BOX_WHITE',
   BOX_YELLOW = 'BOX_YELLOW',
   BOX_BLUE = 'BOX_BLUE',

--- a/weatherfit_refactoring/src/Components/Atoms/Icon/IconStore.tsx
+++ b/weatherfit_refactoring/src/Components/Atoms/Icon/IconStore.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { KeyboardEventHandler } from 'react'
 
-export const enum IconStyle {
+export enum IconStyle {
   MY_PROFILE = 'MY_PROFILE',
   MY_PROFILE_FILL = 'MY_PROFILE_FILL',
   UPLOAD_FILL = 'UPLOAD_FILL',

--- a/weatherfit_refactoring/src/Components/Atoms/Icon/IconStore.tsx
+++ b/weatherfit_refactoring/src/Components/Atoms/Icon/IconStore.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { KeyboardEventHandler } from 'react'
 
-export enum IconStyle {
+export const enum IconStyle {
   MY_PROFILE = 'MY_PROFILE',
   MY_PROFILE_FILL = 'MY_PROFILE_FILL',
   UPLOAD_FILL = 'UPLOAD_FILL',

--- a/weatherfit_refactoring/src/Components/Atoms/Input/InputStore.tsx
+++ b/weatherfit_refactoring/src/Components/Atoms/Input/InputStore.tsx
@@ -5,7 +5,7 @@ import {
   KeyboardEventHandler,
 } from 'react'
 
-export enum InputStyle {
+export const enum InputStyle {
   INPUT_WHITE = 'INPUT_WHITE',
   INPUT_SEARCH = 'INPUT_SEARCH',
   INPUT_IMAGE = 'INPUT_IMAGE',

--- a/weatherfit_refactoring/src/Components/Atoms/Text/TextStore.tsx
+++ b/weatherfit_refactoring/src/Components/Atoms/Text/TextStore.tsx
@@ -1,4 +1,4 @@
-export enum TextStyle {
+export const enum TextStyle {
   GMARKET_TEXT = 'GMARKET_TEXT',
   NANUM_TEXT = 'NANUM_TEXT',
   CAFE_TEXT = 'CAFA_TEXT',


### PR DESCRIPTION
컴파일 후에도 객체가 남아 번들 파일이 불필요하게 커지는 것을 방지하기 위해 const enum으로 변경